### PR TITLE
Add see password functionality, fix create event, add better validation

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -79,7 +79,7 @@ const CustomForm: React.FC<ICustomFormProps> = ({
             switch (requestType) {
                 case "POST":
                     axios
-                        .post(`${process.env["REACT_APP_API_URI"]}api`, {
+                        .post(`${process.env["REACT_APP_API_URI"]}api/`, {
                             title,
                             description,
                             start_time: startTime,

--- a/src/components/LoginPage/LoginPage.tsx
+++ b/src/components/LoginPage/LoginPage.tsx
@@ -9,14 +9,20 @@ import {
     CircularProgress,
     Container,
     Grid,
+    IconButton,
+    InputAdornment,
     Link,
     TextField,
     Typography,
 } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
-import { LockOutlined as LockOutlinedIcon } from "@material-ui/icons";
+import {
+    LockOutlined as LockOutlinedIcon,
+    Visibility,
+    VisibilityOff,
+} from "@material-ui/icons";
 import { Form, Formik } from "formik";
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Redirect, useLocation } from "react-router-dom";
 import * as Yup from "yup";
@@ -48,6 +54,9 @@ const useStyles = makeStyles((theme) => ({
     submit: {
         margin: theme.spacing(3, 0, 2),
     },
+    margin: {
+        marginTop: theme.spacing(1),
+    },
     textField: {
         "& label": {
             color: "grey",
@@ -66,6 +75,17 @@ const SignIn: React.FC = () => {
     const dispatch = useDispatch();
     const location = useLocation();
     const [loading, isAuthenticated, error] = StateHooks.useAuthInfo();
+    const [showPassword, setShowPassword] = useState(false);
+
+    const handleClickShowPassword = () => {
+        setShowPassword((oldShowPassword) => !oldShowPassword);
+    };
+
+    const handleMouseDownPassword = (
+        event: React.MouseEvent<HTMLButtonElement>
+    ) => {
+        event.preventDefault();
+    };
 
     const handleFormSubmit = (values: ILoginFormValues) => {
         const username = values.username;
@@ -115,10 +135,10 @@ const SignIn: React.FC = () => {
                                 username: "",
                             }}
                             validationSchema={Yup.object({
-                                username: Yup.string().required("Required"),
                                 password: Yup.string()
                                     .min(8, "Must be more than 8 characters")
                                     .required("Required"),
+                                username: Yup.string().required("Required"),
                             })}
                             onSubmit={(values, { setSubmitting }) => {
                                 setTimeout(() => {
@@ -135,7 +155,6 @@ const SignIn: React.FC = () => {
                                 handleChange,
                                 handleBlur,
                                 handleSubmit,
-                                setFieldValue,
                                 isSubmitting,
                                 isValid,
                             }) => (
@@ -173,25 +192,48 @@ const SignIn: React.FC = () => {
                                         variant="outlined"
                                         color="primary"
                                         margin="normal"
-                                        required
                                         fullWidth
+                                        required
                                         name="password"
                                         label="Password"
-                                        type="password"
                                         id="password"
-                                        autoComplete="current-password"
+                                        type={
+                                            showPassword ? "text" : "password"
+                                        }
+                                        value={values.password}
                                         onChange={handleChange}
                                         onBlur={handleBlur}
+                                        InputProps={{
+                                            endAdornment: (
+                                                <InputAdornment position="end">
+                                                    <IconButton
+                                                        aria-label="toggle password visibility"
+                                                        onClick={
+                                                            handleClickShowPassword
+                                                        }
+                                                        onMouseDown={
+                                                            handleMouseDownPassword
+                                                        }
+                                                        edge="end"
+                                                    >
+                                                        {showPassword ? (
+                                                            <Visibility />
+                                                        ) : (
+                                                            <VisibilityOff />
+                                                        )}
+                                                    </IconButton>
+                                                </InputAdornment>
+                                            ),
+                                        }}
+                                        error={
+                                            touched.password &&
+                                            Boolean(errors.password)
+                                        }
                                         helperText={
                                             errors.password && touched.password
                                                 ? errors.password
                                                 : ""
                                         }
-                                        error={
-                                            touched.password &&
-                                            Boolean(errors.password)
-                                        }
-                                        value={values.password}
                                     />
                                     <Button
                                         type="submit"

--- a/src/components/PasswordChange/PasswordChange.tsx
+++ b/src/components/PasswordChange/PasswordChange.tsx
@@ -6,13 +6,19 @@ import {
     Button,
     CircularProgress,
     Container,
+    InputAdornment,
+    IconButton,
     TextField,
     Typography,
 } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
-import { SwapHoriz as SwapHorizIcon } from "@material-ui/icons";
+import {
+    SwapHoriz as SwapHorizIcon,
+    Visibility,
+    VisibilityOff,
+} from "@material-ui/icons";
 import { Form, Formik } from "formik";
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import * as Yup from "yup";
 import { auth } from "../../store/actions";
@@ -60,6 +66,25 @@ const PasswordChange: React.FC = () => {
     const classes = useStyles(theme);
     const dispatch = useDispatch();
     const [loading, isAuthenticated, error] = StateHooks.useAuthInfo();
+    const [showPassword1, setShowPassword1] = useState(false);
+    const [showPassword2, setShowPassword2] = useState(false);
+    const [showPassword3, setShowPassword3] = useState(false);
+
+    const handleClickShowPassword1 = () => {
+        setShowPassword1((oldShowPassword: boolean) => !oldShowPassword);
+    };
+    const handleClickShowPassword2 = () => {
+        setShowPassword2((oldShowPassword: boolean) => !oldShowPassword);
+    };
+    const handleClickShowPassword3 = () => {
+        setShowPassword3((oldShowPassword: boolean) => !oldShowPassword);
+    };
+
+    const handleMouseDownPassword = (
+        event: React.MouseEvent<HTMLButtonElement>
+    ) => {
+        event.preventDefault();
+    };
 
     const errorMessage: any[] = [];
     if (error) {
@@ -140,83 +165,146 @@ const PasswordChange: React.FC = () => {
                                 onSubmit={handleSubmit}
                             >
                                 <TextField
+                                    autoFocus
                                     className={classes.textField}
-                                    color="primary"
                                     variant="outlined"
-                                    required
+                                    color="primary"
                                     margin="normal"
                                     fullWidth
+                                    required
                                     name="old_password"
                                     label="Old Password"
-                                    type="password"
                                     id="old_password"
-                                    autoComplete="old-password"
+                                    type={showPassword1 ? "text" : "password"}
+                                    value={values.old_password}
                                     onChange={handleChange}
                                     onBlur={handleBlur}
+                                    InputProps={{
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    aria-label="toggle old password visibility"
+                                                    onClick={
+                                                        handleClickShowPassword1
+                                                    }
+                                                    onMouseDown={
+                                                        handleMouseDownPassword
+                                                    }
+                                                    edge="end"
+                                                >
+                                                    {showPassword1 ? (
+                                                        <Visibility />
+                                                    ) : (
+                                                        <VisibilityOff />
+                                                    )}
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    }}
+                                    error={
+                                        touched.old_password &&
+                                        Boolean(errors.old_password)
+                                    }
                                     helperText={
                                         errors.old_password &&
                                         touched.old_password
                                             ? errors.old_password
                                             : ""
                                     }
-                                    error={
-                                        touched.old_password &&
-                                        Boolean(errors.old_password)
-                                    }
-                                    value={values.old_password}
-                                    autoFocus
                                 />
                                 <TextField
                                     className={classes.textField}
-                                    color="primary"
                                     variant="outlined"
-                                    required
+                                    color="primary"
                                     margin="normal"
                                     fullWidth
+                                    required
                                     name="new_password1"
-                                    label="Confirm Password"
-                                    type="password"
+                                    label="New Password"
                                     id="new_password1"
-                                    autoComplete="new-password"
+                                    type={showPassword2 ? "text" : "password"}
+                                    value={values.new_password1}
                                     onChange={handleChange}
                                     onBlur={handleBlur}
+                                    InputProps={{
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    aria-label="toggle old password visibility"
+                                                    onClick={
+                                                        handleClickShowPassword2
+                                                    }
+                                                    onMouseDown={
+                                                        handleMouseDownPassword
+                                                    }
+                                                    edge="end"
+                                                >
+                                                    {showPassword2 ? (
+                                                        <Visibility />
+                                                    ) : (
+                                                        <VisibilityOff />
+                                                    )}
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    }}
+                                    error={
+                                        touched.new_password1 &&
+                                        Boolean(errors.new_password1)
+                                    }
                                     helperText={
                                         errors.new_password1 &&
                                         touched.new_password1
                                             ? errors.new_password1
                                             : ""
                                     }
-                                    error={
-                                        touched.new_password1 &&
-                                        Boolean(errors.new_password1)
-                                    }
-                                    value={values.new_password1}
                                 />
                                 <TextField
                                     className={classes.textField}
-                                    color="primary"
                                     variant="outlined"
-                                    required
+                                    color="primary"
                                     margin="normal"
                                     fullWidth
+                                    required
                                     name="new_password2"
                                     label="Confirm Password"
-                                    type="password"
                                     id="new_password2"
-                                    autoComplete="confirm-new-password"
+                                    type={showPassword3 ? "text" : "password"}
+                                    value={values.new_password2}
                                     onChange={handleChange}
                                     onBlur={handleBlur}
+                                    InputProps={{
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    aria-label="toggle old password visibility"
+                                                    onClick={
+                                                        handleClickShowPassword3
+                                                    }
+                                                    onMouseDown={
+                                                        handleMouseDownPassword
+                                                    }
+                                                    edge="end"
+                                                >
+                                                    {showPassword3 ? (
+                                                        <Visibility />
+                                                    ) : (
+                                                        <VisibilityOff />
+                                                    )}
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    }}
+                                    error={
+                                        touched.new_password2 &&
+                                        Boolean(errors.new_password2)
+                                    }
                                     helperText={
                                         errors.new_password2 &&
                                         touched.new_password2
                                             ? errors.new_password2
                                             : ""
                                     }
-                                    error={
-                                        touched.new_password2 &&
-                                        Boolean(errors.new_password2)
-                                    }
-                                    value={values.new_password2}
                                 />
                                 <Button
                                     type="submit"
@@ -226,7 +314,7 @@ const PasswordChange: React.FC = () => {
                                     color="primary"
                                     className={classes.submit}
                                 >
-                                    Sign Up
+                                    Change Password
                                 </Button>
                             </Form>
                         )}

--- a/src/components/PasswordResetConfirm/PasswordResetConfirm.tsx
+++ b/src/components/PasswordResetConfirm/PasswordResetConfirm.tsx
@@ -7,13 +7,19 @@ import {
     Button,
     CircularProgress,
     Container,
+    InputAdornment,
+    IconButton,
     TextField,
     Typography,
 } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
-import { Lock as LockIcon } from "@material-ui/icons";
+import {
+    Lock as LockIcon,
+    Visibility,
+    VisibilityOff,
+} from "@material-ui/icons";
 import { Form, Formik } from "formik";
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
 import * as Yup from "yup";
@@ -62,6 +68,21 @@ const PasswordReset: React.FC = () => {
     const dispatch = useDispatch();
     const { uid, token } = useParams();
     const [loading, isAuthenticated, error] = StateHooks.useAuthInfo();
+    const [showPassword1, setShowPassword1] = useState(false);
+    const [showPassword2, setShowPassword2] = useState(false);
+
+    const handleClickShowPassword1 = () => {
+        setShowPassword1((oldShowPassword: boolean) => !oldShowPassword);
+    };
+    const handleClickShowPassword2 = () => {
+        setShowPassword2((oldShowPassword: boolean) => !oldShowPassword);
+    };
+
+    const handleMouseDownPassword = (
+        event: React.MouseEvent<HTMLButtonElement>
+    ) => {
+        event.preventDefault();
+    };
 
     const errorMessage: any[] = [];
     if (error) {
@@ -137,58 +158,99 @@ const PasswordReset: React.FC = () => {
                                 onSubmit={handleSubmit}
                             >
                                 <TextField
+                                    autoFocus
                                     className={classes.textField}
-                                    color="primary"
                                     variant="outlined"
+                                    color="primary"
                                     margin="normal"
-                                    required
                                     fullWidth
+                                    required
                                     name="password"
                                     label="New Password"
-                                    type="password"
                                     id="password"
-                                    autoComplete="current-password"
+                                    type={showPassword1 ? "text" : "password"}
+                                    value={values.password}
                                     onChange={handleChange}
                                     onBlur={handleBlur}
+                                    InputProps={{
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    aria-label="toggle old password visibility"
+                                                    onClick={
+                                                        handleClickShowPassword1
+                                                    }
+                                                    onMouseDown={
+                                                        handleMouseDownPassword
+                                                    }
+                                                    edge="end"
+                                                >
+                                                    {showPassword1 ? (
+                                                        <Visibility />
+                                                    ) : (
+                                                        <VisibilityOff />
+                                                    )}
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    }}
+                                    error={
+                                        touched.password &&
+                                        Boolean(errors.password)
+                                    }
                                     helperText={
                                         errors.password && touched.password
                                             ? errors.password
                                             : ""
                                     }
-                                    error={
-                                        touched.password &&
-                                        Boolean(errors.password)
-                                    }
-                                    value={values.password}
-                                    autoFocus
                                 />
                                 <TextField
                                     className={classes.textField}
-                                    color="primary"
                                     variant="outlined"
+                                    color="primary"
                                     margin="normal"
-                                    required
                                     fullWidth
+                                    required
                                     name="confirmPassword"
                                     label="Confirm Password"
-                                    type="password"
                                     id="confirmPassword"
-                                    autoComplete="confirm-password"
+                                    type={showPassword2 ? "text" : "password"}
+                                    value={values.confirmPassword}
                                     onChange={handleChange}
                                     onBlur={handleBlur}
+                                    InputProps={{
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    aria-label="toggle old password visibility"
+                                                    onClick={
+                                                        handleClickShowPassword2
+                                                    }
+                                                    onMouseDown={
+                                                        handleMouseDownPassword
+                                                    }
+                                                    edge="end"
+                                                >
+                                                    {showPassword2 ? (
+                                                        <Visibility />
+                                                    ) : (
+                                                        <VisibilityOff />
+                                                    )}
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    }}
+                                    error={
+                                        touched.confirmPassword &&
+                                        Boolean(errors.confirmPassword)
+                                    }
                                     helperText={
                                         errors.confirmPassword &&
                                         touched.confirmPassword
                                             ? errors.confirmPassword
                                             : ""
                                     }
-                                    error={
-                                        touched.confirmPassword &&
-                                        Boolean(errors.confirmPassword)
-                                    }
-                                    value={values.confirmPassword}
                                 />
-
                                 <Button
                                     type="submit"
                                     disabled={isSubmitting || !isValid}

--- a/src/components/ProfileEditPage/ProfileEditPage.tsx
+++ b/src/components/ProfileEditPage/ProfileEditPage.tsx
@@ -74,6 +74,7 @@ const Login: React.FC = () => {
     const dispatch = useDispatch();
     const [loading, isAuthenticated, error] = StateHooks.useAuthInfo();
     const handleFormSubmit = (values: IProfileEditFormValues) => {
+        values.age = values.age === "" ? null : values.age;
         dispatch(userActions.updateUserProfile(values));
     };
 
@@ -147,9 +148,20 @@ const Login: React.FC = () => {
                             username: Yup.string().required("Required."),
                             email: Yup.string()
                                 .email("Invalid email address")
-                                .required("Required"),
+                                .required("Required."),
                             over_eighteen: Yup.boolean(),
-                            age: Yup.number().min(1).integer().nullable(),
+                            age: Yup.number()
+                                .min(1)
+                                .integer()
+                                .nullable()
+                                .when("over_eighteen", {
+                                    is: false,
+                                    then: Yup.number()
+                                        .min(1)
+                                        .integer()
+                                        .nullable()
+                                        .required("Required."),
+                                }),
                             previous_volunteer: Yup.boolean(),
                             dietary_restrictions: Yup.string(),
                             medical_restrictions: Yup.string(),

--- a/src/components/SignUpPage/SignUpPage.tsx
+++ b/src/components/SignUpPage/SignUpPage.tsx
@@ -9,14 +9,20 @@ import {
     CircularProgress,
     Container,
     Grid,
+    IconButton,
+    InputAdornment,
     Link,
     TextField,
     Typography,
 } from "@material-ui/core";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
-import { LockOutlined as LockOutlinedIcon } from "@material-ui/icons";
+import {
+    LockOutlined as LockOutlinedIcon,
+    Visibility,
+    VisibilityOff,
+} from "@material-ui/icons";
 import { Form, Formik } from "formik";
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Redirect, useLocation } from "react-router-dom";
 import * as Yup from "yup";
@@ -69,6 +75,22 @@ const SignUp: React.FC = () => {
     const classes = useStyles(theme);
     const dispatch = useDispatch();
     const [loading, isAuthenticated, error] = StateHooks.useAuthInfo();
+    const [showPassword1, setShowPassword1] = useState(false);
+    const [showPassword2, setShowPassword2] = useState(false);
+
+    const handleClickShowPassword1 = () => {
+        setShowPassword1((oldShowPassword: boolean) => !oldShowPassword);
+    };
+    const handleClickShowPassword2 = () => {
+        setShowPassword2((oldShowPassword: boolean) => !oldShowPassword);
+    };
+
+    const handleMouseDownPassword = (
+        event: React.MouseEvent<HTMLButtonElement>
+    ) => {
+        event.preventDefault();
+    };
+
     const handleFormSubmit = (values: ISignupFormValues) => {
         const firstName = values.firstName;
         const lastName = values.lastName;
@@ -287,57 +309,109 @@ const SignUp: React.FC = () => {
                                         <Grid item xs={12}>
                                             <TextField
                                                 className={classes.textField}
-                                                color="primary"
                                                 variant="outlined"
-                                                required
+                                                color="primary"
+                                                margin="normal"
                                                 fullWidth
+                                                required
                                                 name="password"
                                                 label="Password"
-                                                type="password"
                                                 id="password"
-                                                autoComplete="current-password"
+                                                type={
+                                                    showPassword1
+                                                        ? "text"
+                                                        : "password"
+                                                }
+                                                value={values.password}
                                                 onChange={handleChange}
                                                 onBlur={handleBlur}
+                                                InputProps={{
+                                                    endAdornment: (
+                                                        <InputAdornment position="end">
+                                                            <IconButton
+                                                                aria-label="toggle old password visibility"
+                                                                onClick={
+                                                                    handleClickShowPassword1
+                                                                }
+                                                                onMouseDown={
+                                                                    handleMouseDownPassword
+                                                                }
+                                                                edge="end"
+                                                            >
+                                                                {showPassword1 ? (
+                                                                    <Visibility />
+                                                                ) : (
+                                                                    <VisibilityOff />
+                                                                )}
+                                                            </IconButton>
+                                                        </InputAdornment>
+                                                    ),
+                                                }}
+                                                error={
+                                                    touched.password &&
+                                                    Boolean(errors.password)
+                                                }
                                                 helperText={
                                                     errors.password &&
                                                     touched.password
                                                         ? errors.password
                                                         : ""
                                                 }
-                                                error={
-                                                    touched.password &&
-                                                    Boolean(errors.password)
-                                                }
-                                                value={values.password}
                                             />
                                         </Grid>
                                         <Grid item xs={12}>
                                             <TextField
                                                 className={classes.textField}
-                                                color="primary"
                                                 variant="outlined"
-                                                required
+                                                color="primary"
+                                                margin="normal"
                                                 fullWidth
+                                                required
                                                 name="confirmPassword"
                                                 label="Confirm Password"
-                                                type="password"
                                                 id="confirmPassword"
-                                                autoComplete="confirm-password"
+                                                type={
+                                                    showPassword2
+                                                        ? "text"
+                                                        : "password"
+                                                }
+                                                value={values.confirmPassword}
                                                 onChange={handleChange}
                                                 onBlur={handleBlur}
-                                                helperText={
-                                                    errors.confirmPassword &&
-                                                    touched.confirmPassword
-                                                        ? errors.confirmPassword
-                                                        : ""
-                                                }
+                                                InputProps={{
+                                                    endAdornment: (
+                                                        <InputAdornment position="end">
+                                                            <IconButton
+                                                                aria-label="toggle old password visibility"
+                                                                onClick={
+                                                                    handleClickShowPassword2
+                                                                }
+                                                                onMouseDown={
+                                                                    handleMouseDownPassword
+                                                                }
+                                                                edge="end"
+                                                            >
+                                                                {showPassword2 ? (
+                                                                    <Visibility />
+                                                                ) : (
+                                                                    <VisibilityOff />
+                                                                )}
+                                                            </IconButton>
+                                                        </InputAdornment>
+                                                    ),
+                                                }}
                                                 error={
                                                     touched.confirmPassword &&
                                                     Boolean(
                                                         errors.confirmPassword
                                                     )
                                                 }
-                                                value={values.confirmPassword}
+                                                helperText={
+                                                    errors.confirmPassword &&
+                                                    touched.confirmPassword
+                                                        ? errors.confirmPassword
+                                                        : ""
+                                                }
                                             />
                                         </Grid>
                                     </Grid>


### PR DESCRIPTION
# Description:

add see password to password fields, fix event create, better validation to the edit profile page

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Limitations:

Please describe limitations of this PR

# Testing:

I touched all password fields, probs make sure they still work (check all the files i touched). worked when i tested them tho

# Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
