### PR TITLE
Add state to calendar navigation

### DIFF
--- a/src/components/Calendar/EventCategory.tsx
+++ b/src/components/Calendar/EventCategory.tsx
@@ -31,7 +31,7 @@ import {
 import moment from "moment";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
-import { Link } from "react-router-dom";
+import { useHistory, useRouteMatch } from "react-router-dom";
 import { volunteer as volunteerActions } from "../../store/actions";
 import { StateHooks } from "../../store/hooks";
 import { Loading } from "../Loading";
@@ -80,6 +80,12 @@ interface IRenderRowProps {
     data: any[];
     index: number;
     request: any;
+}
+
+interface IEventCategory {
+    event: any;
+    selectedCategories: string[];
+    defaultDate: Date;
 }
 
 const useStyles = makeStyles((theme) =>
@@ -215,7 +221,13 @@ const RoleSelect: React.FC<IRoleSelectProps> = ({
     );
 };
 
-const EventCategory = ({ event }: { event: any }) => {
+const EventCategory = ({
+    event,
+    selectedCategories,
+    defaultDate,
+}: IEventCategory) => {
+    const history = useHistory();
+    const { url } = useRouteMatch();
     const theme = useTheme();
     const classes = useStyles(theme);
     const dispatch = useDispatch();
@@ -226,6 +238,12 @@ const EventCategory = ({ event }: { event: any }) => {
     const [submitRequest, setSubmitRequest] = useState<any>();
     const mappedRoles = StateHooks.useMappedRoles();
     const { requests } = event;
+
+    const browserState = {
+        oldCategoryView: true,
+        oldDefaultDate: defaultDate,
+        oldSelectedCategories: selectedCategories,
+    };
 
     const isPositionFull = () => {
         return event.number_of_open_positions === 0;
@@ -240,12 +258,12 @@ const EventCategory = ({ event }: { event: any }) => {
     };
 
     const handleAccept = (request: any) => {
-        dispatch(volunteerActions.acceptRequest(request));
+        dispatch(volunteerActions.acceptRequest(request, url, browserState));
         handleClosePopover();
     };
 
     const handleDeny = (request: any) => {
-        dispatch(volunteerActions.denyRequest(request));
+        dispatch(volunteerActions.denyRequest(request, url, browserState));
         handleClosePopover();
     };
 
@@ -291,7 +309,9 @@ const EventCategory = ({ event }: { event: any }) => {
                     dispatch(
                         volunteerActions.changeRequestRole(
                             submitRequest,
-                            submitRole
+                            submitRole,
+                            url,
+                            browserState
                         )
                     );
                 }
@@ -301,6 +321,11 @@ const EventCategory = ({ event }: { event: any }) => {
 
         const handleSubmit = (_event: React.FormEvent<HTMLFormElement>) => {
             handleOkClick(roleID);
+        };
+
+        const handleProfileClick = () => {
+            history.replace(url, browserState);
+            history.push(`/volunteer/users/${request.user_profile.pk}`);
         };
 
         return (
@@ -318,11 +343,13 @@ const EventCategory = ({ event }: { event: any }) => {
                                 }}
                             >
                                 <Typography>
-                                    <Link
-                                        to={`/volunteer/users/${request.user_profile.pk}`}
+                                    <Button
+                                        onClick={handleProfileClick}
+                                        size="medium"
+                                        color="primary"
                                     >
                                         {`${request.user_profile.first_name} ${request.user_profile.last_name}`}
-                                    </Link>
+                                    </Button>
                                 </Typography>
                             </ListItemText>
 

--- a/src/components/Calendar/EventsCalendar.tsx
+++ b/src/components/Calendar/EventsCalendar.tsx
@@ -2,24 +2,8 @@
 // tslint:disable: react-this-binding-issue
 // tslint:disable: use-simple-attributes
 import { Container, Zoom } from "@material-ui/core";
-import axios from "axios";
-import * as chroma from "chroma-js";
-import moment from "moment";
-import React, { useEffect, useState } from "react";
-import {
-    Calendar,
-    EventPropGetter,
-    momentLocalizer,
-    ToolbarProps,
-    Views,
-} from "react-big-calendar";
-// tslint:disable-next-line: no-submodule-imports
-import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
-// tslint:disable-next-line: no-submodule-imports
-import "react-big-calendar/lib/css/react-big-calendar.css";
-import { useDispatch } from "react-redux";
-import { UserUrls } from "../../constants";
-import { volunteer as volunteerActions } from "../../store/actions";
+import React, { useState } from "react";
+import { useLocation } from "react-router-dom";
 import { StateHooks } from "../../store/hooks";
 import EventsCategoryView from "./EventsCategoryView";
 import EventsDetailView from "./EventsDetailView";
@@ -38,17 +22,29 @@ export type VolunteerCategoryType = {
     category: string;
 };
 
-const EventsCalendar: React.FC = () => {
-    const dispatch = useDispatch();
-    const [currentList, setList] = useState<VolunteerCategoryType[]>([]);
-    const [originalList, setOriginalList] = useState<VolunteerCategoryType[]>(
-        []
-    );
-    const [modalOpen, setModalOpen] = useState<boolean>(false);
-    const [categoryView, setCategoryView] = useState<boolean>(false);
+interface ILocationState {
+    oldCategoryView: boolean | undefined;
+    oldSelectedCategories: string[] | undefined;
+    oldDefaultDate: Date | undefined;
+}
 
-    const token = StateHooks.useToken();
-    const [defaultDate, setDefaultDate] = useState<Date>(new Date(2021, 4, 22));
+const EventsCalendar: React.FC = () => {
+    const { state } = useLocation<ILocationState>();
+
+    const defaultIsCategoryView =
+        state && state.oldCategoryView !== undefined
+            ? state.oldCategoryView
+            : false;
+
+    const [categoryView, setCategoryView] = useState<boolean>(
+        defaultIsCategoryView
+    );
+
+    const defaultDefaultDate =
+        state && state.oldDefaultDate !== undefined
+            ? state.oldDefaultDate
+            : new Date(2021, 4, 22);
+    const [defaultDate, setDefaultDate] = useState<Date>(defaultDefaultDate);
 
     const volunteerCategories = StateHooks.useVolunteerCategoryTypes();
     const volunteerCategoryTypeTags = volunteerCategories.map(
@@ -57,8 +53,12 @@ const EventsCalendar: React.FC = () => {
         }
     );
 
+    const defaultSelectedCategories =
+        state && state.oldSelectedCategories !== undefined
+            ? state.oldSelectedCategories
+            : volunteerCategoryTypeTags;
     const [selectedCategories, setSelectedCategories] = useState<string[]>(
-        volunteerCategoryTypeTags
+        defaultSelectedCategories
     );
 
     return (

--- a/src/components/Calendar/EventsCategoryView.tsx
+++ b/src/components/Calendar/EventsCategoryView.tsx
@@ -180,6 +180,16 @@ const EventsCategoryView: React.FC<IEventsCategoryView> = (props) => {
         (c) => props.selectedCategories.indexOf(c.tag) > -1
     );
 
+    const WrappedEventCategory = ({ event }: { event: any }) => {
+        return (
+            <EventCategory
+                event={event}
+                defaultDate={props.defaultDate}
+                selectedCategories={props.selectedCategories}
+            />
+        );
+    };
+
     return (
         <Container maxWidth="lg">
             {loading ? (
@@ -200,7 +210,7 @@ const EventsCategoryView: React.FC<IEventsCategoryView> = (props) => {
                         defaultDate={props.defaultDate}
                         views={{ day: true, week: UFestWeek }}
                         components={{
-                            event: EventCategory,
+                            event: WrappedEventCategory,
                             toolbar: (tbarProps: ToolbarProps) => (
                                 <CalendarToolbar
                                     {...tbarProps}

--- a/src/store/actions/volunteer.ts
+++ b/src/store/actions/volunteer.ts
@@ -295,7 +295,11 @@ export const getMappedVolunteerRoles = () => {
     };
 };
 
-export const acceptRequest = (request: any) => {
+export const acceptRequest = (
+    request: any,
+    redirectUrl: string,
+    browserState: any
+) => {
     console.log("request", request);
     const token = localStorage.getItem("token");
     return (dispatch: DispatchType) => {
@@ -312,6 +316,7 @@ export const acceptRequest = (request: any) => {
                 })
                 .then((res) => {
                     dispatch(acceptRequestSuccess());
+                    history.replace(redirectUrl, browserState);
                     history.go(0);
                     console.log(res);
                 })
@@ -323,7 +328,11 @@ export const acceptRequest = (request: any) => {
     };
 };
 
-export const denyRequest = (request: any) => {
+export const denyRequest = (
+    request: any,
+    redirectUrl: string,
+    browserState: any
+) => {
     const token = localStorage.getItem("token");
     return (dispatch: DispatchType) => {
         if (token) {
@@ -339,6 +348,7 @@ export const denyRequest = (request: any) => {
                 })
                 .then((res) => {
                     dispatch(denyRequestSuccess());
+                    history.replace(redirectUrl, browserState);
                     history.go(0);
                     console.log(res);
                 })
@@ -350,7 +360,12 @@ export const denyRequest = (request: any) => {
     };
 };
 
-export const changeRequestRole = (request: any, role: any) => {
+export const changeRequestRole = (
+    request: any,
+    role: any,
+    redirectUrl: string,
+    browserState: any
+) => {
     const token = localStorage.getItem("token");
     const payload = {
         ...request,
@@ -369,6 +384,7 @@ export const changeRequestRole = (request: any, role: any) => {
                 .then((res) => {
                     dispatch(changeRequestRoleSuccess());
                     console.log(res);
+                    history.replace(redirectUrl, browserState);
                     history.go(0);
                 })
                 .catch((err) => {


### PR DESCRIPTION
# Description:

makes it so that actions on the calendar view retain state, specifically the category view

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Limitations:

Please describe limitations of this PR

# Testing:

make sure that the major actions on the category view all retain history ie accept deny and swap requests stay on the same page after refresh and back button from the user profile view retains the same filters and such

-   [ ] Test A
-   [ ] Test B

# Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
