### PR TITLE
add calendar view to volunteer request page

### DIFF
--- a/src/components/Calendar/MySchedule.tsx
+++ b/src/components/Calendar/MySchedule.tsx
@@ -22,6 +22,7 @@ import { RequestEvent } from "./RequestEvent";
 import { getEarliestDate } from "../../utils";
 import UFestWeek from "./UFestWeek";
 import UFestDay from "./UFestDay";
+import { Loading } from "../Loading";
 
 type UserRequestType = {
     id: number;
@@ -78,6 +79,7 @@ const MySchedule: React.FC<ScheduleProps> = ({ requests }: ScheduleProps) => {
     const classes = useStyles(theme);
     const dispatch = useDispatch();
     const [currentList, setList] = useState<UserRequestType[]>([]);
+    const [_categories, loading, _error] = StateHooks.useVolunteerInfo();
     const [cookies, _setCookie] = useCookies(["csrftoken"]);
 
     const token = StateHooks.useToken();
@@ -135,31 +137,35 @@ const MySchedule: React.FC<ScheduleProps> = ({ requests }: ScheduleProps) => {
     console.log(`Earliest date ${earliest}`);
     return (
         <Container maxWidth="lg">
-            <Calendar
-                localizer={localizer}
-                events={currentList}
-                startAccessor="start_time"
-                endAccessor="end_time"
-                style={{ height: 600 }}
-                defaultView="day"
-                defaultDate={earliest}
-                views={{ day: UFestDay, week: UFestWeek }}
-                components={{
-                    event: RequestEvent,
-                    toolbar: (props: ToolbarProps) => (
-                        <CalendarToolbar
-                            {...props}
-                            categoryView={false}
-                            filter={false}
-                            addButton={false}
-                        />
-                    ),
-                }}
-                selectable
-                popup={true}
-                scrollToTime={moment("08:00:00 am", "hh:mm:ss a").toDate()}
-                eventPropGetter={customRequestStyle}
-            />
+            {loading ? (
+                <Loading />
+            ) : (
+                <Calendar
+                    localizer={localizer}
+                    events={currentList}
+                    startAccessor="start_time"
+                    endAccessor="end_time"
+                    style={{ height: 600 }}
+                    defaultView="day"
+                    defaultDate={earliest}
+                    views={{ day: UFestDay, week: UFestWeek }}
+                    components={{
+                        event: RequestEvent,
+                        toolbar: (props: ToolbarProps) => (
+                            <CalendarToolbar
+                                {...props}
+                                categoryView={false}
+                                filter={false}
+                                addButton={false}
+                            />
+                        ),
+                    }}
+                    selectable
+                    popup={true}
+                    scrollToTime={moment("08:00:00 am", "hh:mm:ss a").toDate()}
+                    eventPropGetter={customRequestStyle}
+                />
+            )}
         </Container>
     );
 };

--- a/src/components/Calendar/UFestDay.tsx
+++ b/src/components/Calendar/UFestDay.tsx
@@ -54,7 +54,7 @@ class UFestDay extends React.Component<{
 
         const earliest = getEarliestDate(eventDates);
         const latest = getLatestDate(eventDates);
-        console.log(`UFEST WEEK${eventDates} ${earliest} ${latest}`);
+
         if (earliest) {
             UFEST_VOLUNTEERING_START_DATE = earliest;
         }

--- a/src/components/Calendar/UFestWeek.tsx
+++ b/src/components/Calendar/UFestWeek.tsx
@@ -62,7 +62,7 @@ class UFestWeek extends React.Component<{
 
         const earliest = getEarliestDate(eventDates);
         const latest = getLatestDate(eventDates);
-        console.log(`UFEST WEEK${eventDates} ${earliest} ${latest}`);
+
         if (earliest) {
             UFEST_VOLUNTEERING_START_DATE = earliest;
         }

--- a/src/components/LoginPage/LoginPage.tsx
+++ b/src/components/LoginPage/LoginPage.tsx
@@ -105,9 +105,10 @@ const SignIn: React.FC = () => {
             {isAuthenticated ? (
                 <Redirect
                     to={{
-                        pathname: "/volunteer",
+                        pathname: "/volunteer/profile/edit",
                         state: {
                             from: location,
+                            fromLoginPage: true,
                         },
                     }}
                 />

--- a/src/components/PositionRequestPage/PositionRequestPage.tsx
+++ b/src/components/PositionRequestPage/PositionRequestPage.tsx
@@ -111,7 +111,6 @@ const PositionRequestPage: React.FC = () => {
     const userProfile = StateHooks.useUserProfile();
     const [cookies, _setCookie] = useCookies(["csrftoken"]);
     const [currentList, setList] = useState<ScheduleEventType[]>([]);
-    const [currentCategory, setCategory] = useState<string>("");
 
     const token = StateHooks.useToken();
     const eventDates = StateHooks.useEventDates();
@@ -145,13 +144,20 @@ const PositionRequestPage: React.FC = () => {
                     let mappedData;
                     if (roleID != undefined) {
                         const category = data.pop();
-                        setCategory(category.role_title);
+                        // In this case we only look at one of the event roles that matches the name received from the badckend
                         mappedData = data.map((d: any) => {
+                            const role = d.roles.find(
+                                (r: any) =>
+                                    r.title.toLowerCase() ===
+                                    category.role_title.toLowerCase()
+                            );
+                            d.role = JSON.parse(JSON.stringify(role));
                             d.start_time = new Date(d.start_time);
                             d.end_time = new Date(d.end_time);
                             return d;
                         });
                     } else {
+                        // In this case we look at tall the roles under an event
                         mappedData = data.reduce(
                             (accum: any, d: any) =>
                                 accum.concat(
@@ -166,7 +172,8 @@ const PositionRequestPage: React.FC = () => {
                             []
                         );
                     }
-                    console.log(`mappedData ${mappedData}`);
+                    console.log("mappedData");
+                    console.log(mappedData);
                     setList(mappedData);
                 })
                 .catch((err) => console.error(err));
@@ -188,8 +195,8 @@ const PositionRequestPage: React.FC = () => {
             null
         );
 
-        const handleClick = (clickEvent: React.MouseEvent<HTMLDivElement>) => {
-            setAnchorEl(clickEvent.currentTarget);
+        const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+            setAnchorEl(event.currentTarget);
         };
 
         const handleClose = () => {
@@ -261,27 +268,17 @@ const PositionRequestPage: React.FC = () => {
 
         const open = Boolean(anchorEl);
         const id = open ? "simple-popover" : undefined;
-        const selectedRole =
-            roleID != undefined
-                ? event.roles.find(
-                      (r: any) =>
-                          r.title.toLowerCase() ===
-                          currentCategory.toLowerCase()
-                  )
-                : event.role;
+        const selectedRole = event.role;
 
         const noPositionsLeft =
             selectedRole === undefined ||
             selectedRole?.number_of_open_positions === 0;
 
-        if (roleID == undefined) {
-            setCategory(event.role.title);
-        }
         return (
             <>
                 <Container onClick={handleClick} className={classes.eventRoot}>
                     {errorMessage}
-                    <strong>{event.title}</strong> : {currentCategory}
+                    <strong>{event.title}</strong> : {event.role.title}
                     <br />
                     Available Positions:{" "}
                     {selectedRole?.number_of_positions != null &&

--- a/src/components/RoleSelectPage/RoleSelectPage.tsx
+++ b/src/components/RoleSelectPage/RoleSelectPage.tsx
@@ -1,10 +1,14 @@
 // tslint:disable: use-simple-attributes
 import {
     Divider,
+    FormControl,
     Grid,
+    InputLabel,
     List,
     ListItem,
     ListItemText,
+    MenuItem,
+    Select,
     Typography,
 } from "@material-ui/core";
 // tslint:disable-next-line: no-submodule-imports
@@ -15,6 +19,7 @@ import { useDispatch } from "react-redux";
 import { Link, useParams, useRouteMatch } from "react-router-dom";
 import { volunteer as volunteerActions } from "../../store/actions";
 import { StateHooks } from "../../store/hooks";
+import { PositionRequestPage } from "../PositionRequestPage";
 
 const useStyles = makeStyles((theme) =>
     createStyles({
@@ -74,6 +79,9 @@ const useStyles = makeStyles((theme) =>
             marginRight: 8,
             padding: "2%",
         },
+        calendarContainer: {
+            width: "-webkit-fill-available",
+        },
     })
 );
 
@@ -84,6 +92,7 @@ const RoleSelectPage: React.FC = () => {
     const { url } = useRouteMatch();
     const { categoryTypeID } = useParams();
     const [cookies, _setCookie] = useCookies(["csrftoken"]);
+    const [view, setView] = React.useState("list");
     const volunteerCategories = StateHooks.useVolunteerCategories();
     const roles = volunteerCategories.map((category, idx, _arr) => {
         return category.roles;
@@ -113,6 +122,10 @@ const RoleSelectPage: React.FC = () => {
             )
         );
     }, [cookies.csrftoken, dispatch, categoryTypeID]);
+
+    const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+        setView(event.target.value as string);
+    };
 
     const ListItems = () => {
         const flatRoles = Object.values(combinedRoles);
@@ -202,10 +215,29 @@ const RoleSelectPage: React.FC = () => {
         >
             <Grid item>
                 <Typography variant="h2">Request to Volunteer</Typography>
+                <FormControl fullWidth>
+                    <InputLabel id="demo-simple-select-label">View</InputLabel>
+                    <Select
+                        labelId="demo-simple-select-label"
+                        id="demo-simple-select"
+                        value={view}
+                        label="View"
+                        onChange={handleChange}
+                    >
+                        <MenuItem value={"list"}>List View</MenuItem>
+                        <MenuItem value={"calendar"}>Calendar View</MenuItem>
+                    </Select>
+                </FormControl>
             </Grid>
-            <Grid item>
-                <List className={classes.list}>{ListItems()}</List>
-            </Grid>
+            {view == "calendar" ? (
+                <Grid item className={classes.calendarContainer}>
+                    <PositionRequestPage />
+                </Grid>
+            ) : (
+                <Grid item>
+                    <List className={classes.list}>{ListItems()}</List>
+                </Grid>
+            )}
         </Grid>
     );
 };

--- a/src/components/RoleSelectPage/RoleSelectPage.tsx
+++ b/src/components/RoleSelectPage/RoleSelectPage.tsx
@@ -216,10 +216,12 @@ const RoleSelectPage: React.FC = () => {
             <Grid item>
                 <Typography variant="h2">Request to Volunteer</Typography>
                 <FormControl fullWidth>
-                    <InputLabel id="demo-simple-select-label">View</InputLabel>
+                    <InputLabel id="volunter-view-select-label">
+                        View
+                    </InputLabel>
                     <Select
-                        labelId="demo-simple-select-label"
-                        id="demo-simple-select"
+                        labelId="volunter-view-select-label"
+                        id="volunter-view-select"
                         value={view}
                         label="View"
                         onChange={handleChange}
@@ -229,7 +231,7 @@ const RoleSelectPage: React.FC = () => {
                     </Select>
                 </FormControl>
             </Grid>
-            {view == "calendar" ? (
+            {view === "calendar" ? (
                 <Grid item className={classes.calendarContainer}>
                     <PositionRequestPage />
                 </Grid>

--- a/src/constants/volunteerUrls.ts
+++ b/src/constants/volunteerUrls.ts
@@ -6,11 +6,11 @@ const VolunteerUrls = {
     CATEGORY_TYPE_LIST: `${ROOT_URL}api/categories/`,
     CATEGORY_DETAILS: (categoryID: number) =>
         `${ROOT_URL}api/positions/${categoryID}/`,
-    CATEGORY_LIST: `${ROOT_URL}api/positions/`,
+    CATEGORY_LIST: `${ROOT_URL}api/positions/?use_event_dates=true`,
     CATEGORIES_OF_TYPE_LIST: (categoryTypeID: number) =>
-        `${ROOT_URL}api/positions/category/${categoryTypeID}/`,
+        `${ROOT_URL}api/positions/category/${categoryTypeID}/?use_event_dates=true`,
     CATEGORIES_WITH_ROLE_LIST: (categoryTypeID: number, roleID: number) =>
-        `${ROOT_URL}api/positions/category/${categoryTypeID}/roles/${roleID}/`,
+        `${ROOT_URL}api/positions/category/${categoryTypeID}/roles/${roleID}/?use_event_dates=true`,
     REQUESTS: `${ROOT_URL}api/requests/`,
     REQUESTS_DETAILS: (requestID: number) =>
         `${ROOT_URL}api/requests/${requestID}/`,

--- a/src/store/actions/user.ts
+++ b/src/store/actions/user.ts
@@ -134,7 +134,7 @@ export const updateUserProfile = (
                 };
                 dispatch(updateProfileSuccess());
                 dispatch(success(notificationOpts));
-                history.push("/volunteer/profile/info");
+                history.push("/volunteer");
             })
             .catch((reqError) => {
                 // If request is bad...


### PR DESCRIPTION
# Description:

Add a new view in the volunteer request flow so that a volunteer can see all roles in a specific category in calendar format, instead of selecting a certain role before being able to see the calendar view. The existing list view is still available. 

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Limitations:

Please describe limitations of this PR

# Testing:

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] Request a role from the new calendar view 
-   [ ] Request a role from the existing list view

# Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] My code has been formatted with `npm run format` and passes the checks in `npm run check`
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
